### PR TITLE
Add more minor improvements and tests with QuickCheck

### DIFF
--- a/oshit.cabal
+++ b/oshit.cabal
@@ -85,6 +85,7 @@ test-suite spec
     , time-lens
 
   other-modules:
+    Core.CoreSpec
     Core.ReflogSpec
     Test.Oshit
 

--- a/oshit.cabal
+++ b/oshit.cabal
@@ -91,9 +91,11 @@ test-suite spec
     , safe
     , directory
     , temporary
+    , filepath
 
   other-modules:
     Core.CoreSpec
+    Core.ObjectSpec
     Core.ReflogSpec
     Util.UtilSpec
     Test.Oshit

--- a/oshit.cabal
+++ b/oshit.cabal
@@ -83,10 +83,17 @@ test-suite spec
     , bytestring
     , time
     , time-lens
+    , formatting
+    , text
+    , ilist == 0.4.0.1
+    , containers
+    , deepseq
+    , safe
 
   other-modules:
     Core.CoreSpec
     Core.ReflogSpec
+    Util.UtilSpec
     Test.Oshit
 
   default-language: Haskell2010

--- a/oshit.cabal
+++ b/oshit.cabal
@@ -25,6 +25,7 @@ library
                , time
                , process
                , extra >=1.7.10 && <1.8
+               , filepath
 
   exposed-modules:
     Core.Core

--- a/oshit.cabal
+++ b/oshit.cabal
@@ -57,6 +57,12 @@ library
     Commands.Porcelain.Reference.Branch
     Commands.Porcelain.Reflog
 
+  other-modules:
+    Core.Object.Core
+    Core.Object.Blob
+    Core.Object.Commit
+    Core.Object.Tree
+
 executable oshit
   main-is: Main.hs
   hs-source-dirs: app

--- a/oshit.cabal
+++ b/oshit.cabal
@@ -89,6 +89,8 @@ test-suite spec
     , containers
     , deepseq
     , safe
+    , directory
+    , temporary
 
   other-modules:
     Core.CoreSpec

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -8,7 +8,17 @@ import System.Environment
 type Command = [String] -> IO ()
 type Hash = B.ByteString
 
-data FileMode = StdMode | DirMode
+data FileMode = StdMode | DirMode deriving (Eq)
+
+instance Show FileMode where
+  show StdMode = "100644"
+  show DirMode = "40000"
+
+instance Read FileMode where
+  readsPrec _ = parsedModes . parseOctal
+    where parsedModes 0o100644 = [(StdMode, "")]
+          parsedModes 0o040000 = [(DirMode, "")]
+          parsedModes _ = []
 
 defaultEditor :: IO String
 defaultEditor = getEnv "EDITOR"
@@ -18,14 +28,3 @@ authorName = getEnv "OSHIT_AUTHOR"
 
 authorEmail :: IO String
 authorEmail = getEnv "OSHIT_EMAIL"
-
-fileModeFromString :: String -> Maybe FileMode
-fileModeFromString = fileModeFromString' . parseOctal
-  where fileModeFromString' :: Int -> Maybe FileMode
-        fileModeFromString' 0o100644 = Just StdMode
-        fileModeFromString' 0o040000 = Just DirMode
-        fileModeFromString' _        = Nothing
-
-stringFromFileMode :: FileMode -> String
-stringFromFileMode StdMode = "100644"
-stringFromFileMode DirMode = "40000"

--- a/src/Core/Object.hs
+++ b/src/Core/Object.hs
@@ -5,57 +5,44 @@
 --
 -- Maintainer  : lucasseikioshiro@gmail.com
 --
--- This module contains the definitions of the 'Object' typeclass as well as
--- Git objects such as 'Tree', 'Commit' and 'Blob'.
+-- This module exports the definitions of Git objects.
 --------------------------------------------------------------------------------
 
-module Core.Object where
+module Core.Object (
+    module Core.Object.Core,
+    module Core.Object.Tree,
+    module Core.Object.Commit,
+    module Core.Object.Blob,
 
-import Control.Monad.Extra (unlessM)
+    -- temporary
+    Tree(..),
+    TreeIO,
+    CommitIO,
+    listTreeRecursive,
+    loadTree,
+    treeContentsRecursive,
+    treesFromContents,
+    insertToInnerTree,
+    InnerTreeNode(..),
+    loadBlob,
+    loadCommit,
+    treesFromInnerTrees
+  ) where
+
+import Core.Object.Core
+import Core.Object.Blob
+import Core.Object.Commit
+import Core.Object.Tree
+
 import Data.Either
 import Data.List
 import Data.List.Split
-import Data.Maybe
-import Data.Time
-import Text.Read (readMaybe)
-import System.FilePath (takeDirectory)
 
-import qualified Codec.Compression.Zlib     as Zlib
-import qualified Crypto.Hash.SHA1           as SHA1
 import qualified Data.ByteString.Base16     as B16
 import qualified Data.ByteString.Char8      as B
-import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Map                   as Map
-import qualified System.Directory           as Dir
 
 import Core.Core
-import Core.Packfile
-
--- | Helper type to enumerate valid Git object types.
-data ObjectType = BlobType | TreeType | CommitType
-
-newtype Tree = Tree [(FileMode, FilePath, Hash)]
-newtype Blob = Blob B.ByteString
-
-data Commit = Commit
-  { treeHash  :: Hash
-  , parents   :: [Hash]
-  , author    :: String
-  , email     :: String
-  , timestamp :: ZonedTime
-  , message   :: String
-  }
-
--- | Typeclass for Git objects.
-class Object obj where
-  -- | Returns the object type.
-  objectType       :: obj -> ObjectType
-  -- | Parse a 'B.ByteString' into an object of the given type.
-  objectParse      :: B.ByteString -> IO obj
-  -- | Serialize the object into a 'B.ByteString'.
-  objectRawContent :: obj -> B.ByteString
-  -- | Pretty print the object.
-  objectPretty     :: obj -> String
 
 type BlobIO   = IO Blob
 type TreeIO   = IO Tree
@@ -67,83 +54,6 @@ data InnerTreeNode = InnerLeaf Hash
                    | InnerTree FilePath (Map.Map FilePath InnerTreeNode)
 
 data HashedInnerTree = HashedInnerTree (Hash, Tree, [HashedInnerTree])
-
-instance Read ObjectType where
-  readsPrec _ "blob"   = [(BlobType,   "")]
-  readsPrec _ "tree"   = [(TreeType,   "")]
-  readsPrec _ "commit" = [(CommitType, "")]
-  readsPrec _ _        = []
-
-instance Show ObjectType where
-  show BlobType   = "blob"
-  show TreeType   = "tree"
-  show CommitType = "commit"
-
--- | Compute the SHA1 hash of an object.
-hashObject :: Object obj => obj -> Hash
-hashObject = B16.encode . SHA1.hash . objectFileContent
-
--- | Compresses a 'B.ByteString' using zlib.
-compress :: B.ByteString -> B.ByteString
-compress = L.toStrict . Zlib.compress . L.fromStrict
-
--- | Decompresses a 'B.ByteString' using zlib.
-decompress :: B.ByteString -> B.ByteString
-decompress = L.toStrict . Zlib.decompress . L.fromStrict
-
--- | Stores a compressed Git object on disk.
---
--- TODO: Support packfiles.
-storeObject :: Object o => o -> IO ()
-storeObject obj = do
-  let objectPath = hashPath $ hashObject obj
-  Dir.createDirectoryIfMissing True $ takeDirectory objectPath
-  unlessM (Dir.doesDirectoryExist objectPath) $ do
-    B.writeFile objectPath $ compress (objectFileContent obj)
-
--- | Loads a Git object from disk and attempts to parse it.
-loadObjectLegacy :: Object obj => Hash -> IO obj
-loadObjectLegacy hash = loadRawObject hash >>= objectParse
-
--- | Loads a loose Git object from disk as a 'B.ByteString'.
-loadLooseRawObject :: Hash -> IO B.ByteString
-loadLooseRawObject hash = B.readFile (hashPath hash) >>= return . decompress
-
--- | Loads a packed Git object from disk as a 'Maybe'@ @'B.ByteString'.
-loadPackedRawObject :: Hash -> IO (Maybe B.ByteString)
-loadPackedRawObject hash = do
-  obj <- searchInPackFiles hash
-  return $ do
-    (objType, content) <- obj
-
-    typeStr <- case objType of
-                    PackBlob   -> Just . B.pack $ "blob"
-                    PackTree   -> Just . B.pack $ "tree"
-                    PackCommit -> Just . B.pack $ "commit"
-                    _          -> Nothing
-
-    let decompressed = decompress content
-        size = B.length decompressed
-
-    return . B.concat $ [ typeStr
-                        , B.pack " "
-                        , B.pack . show $ size
-                        , B.pack "\0"
-                        , decompressed
-                        ]
-
--- | Loads a Git object from disk (either loose or packed) as a 'B.ByteString'.
-loadRawObject :: Hash -> IO B.ByteString
-loadRawObject hash = do
-  exists <- looseObjectExists . B.unpack $ hash
-  if exists
-    then loadLooseRawObject $ hash
-    else do
-      packed <- loadPackedRawObject hash
-
-      case packed of
-        Just b -> return b
-        Nothing -> fail "object not found"
 
 -- | Loads a Git object from disk as an 'ObjectIO'.
 loadObject :: Hash -> ObjectIO
@@ -168,141 +78,7 @@ loadCommit :: Hash -> CommitIO
 loadCommit hash = commitIO
   where (ObjectIO _ _ commitIO) = loadObject hash
 
--- | Get the uncompressed contents of an object as a 'B.ByteString'.
-objectFileContent :: Object obj => obj -> B.ByteString
-objectFileContent obj = uncompressed
-  where content      = objectRawContent obj
-        size         = B.pack $ show $ B.length content
-        objType      = objectType obj
-        uncompressed = B.concat [ B.pack $ show objType
-                                , B.pack " "
-                                , size
-                                , B.pack "\0", content]
-
--- | Tries to parse the type of a Git object from its uncompressed contents.
-rawObjectType :: B.ByteString -> Maybe ObjectType
-rawObjectType = readMaybe . B.unpack . B.takeWhile (/= ' ')
-
--- | Returns the path to the object file given its hash.
---
--- >>> hashPath "aabbccddeeff"
--- ".git/objects/aa/bbccddeeff"
-hashPath :: Hash -> FilePath
-hashPath hash = concat [".git/objects/", dir, "/", filename]
-  where (dir, filename) = splitAt 2 $ B.unpack hash
-
--- | Determines if a loose object file exists given its hash as a string.
-looseObjectExists :: String -> IO Bool
-looseObjectExists = Dir.doesFileExist . hashPath . B.pack
-
--- Blob
-
-instance Object Blob where
-  objectParse bs = case objType of
-    Just BlobType -> return . Blob $ content
-    _             -> fail "Not a blob"
-    where objType = rawObjectType bs
-          content = (B.split '\0' bs) !! 1
-
-  objectType _ = BlobType
-
-  objectRawContent (Blob content) = content
-
-  objectPretty (Blob bs) = B.unpack bs
-
--- Commit
-
-gitTimeFormat :: String
-gitTimeFormat = "%s %z"
-
-instance Object Commit where
-  objectType _ = CommitType
-
-  objectParse raw =
-    case objType of
-      Just CommitType -> return commit
-      _           -> fail "Not a commit"
-
-    where objType      = rawObjectType raw
-          content      = (B.drop 1) . (B.dropWhile (/= '\0')) $ raw
-          linesB       = B.split '\n' content
-          headerLines  = takeWhile (/= B.empty) linesB
-          treeLine     = headerLines !! 0
-          parentsLines = (takeWhile $ B.isPrefixOf $ B.pack "parent") .
-                         (drop 1) $
-                         headerLines
-          authorLine   = headerLines !! (length parentsLines + 1)
-
-          tree       = B.drop (length "tree ") treeLine
-          parents'   = [ B.drop (length "parent ") line
-                       | line <- parentsLines
-                       ]
-          author'    = B.unpack .
-                       B.init .
-                       B.takeWhile (/= '<') .
-                       B.drop (length "author ") $
-                       authorLine
-          email'     = B.unpack .
-                       B.takeWhile (/= '>') .
-                       B.drop 1 .
-                       B.dropWhile (/= '<') $
-                       authorLine
-          timestampM :: Maybe ZonedTime
-          timestampM = parseTimeM True defaultTimeLocale gitTimeFormat .
-                       B.unpack .
-                       B.drop 2 .
-                       B.dropWhile (/= '>') $
-                       authorLine
-          timestamp' = fromJust timestampM
-          message'   = B.unpack $
-                       B.drop (1 + length headerLines + (sum $ map B.length headerLines)) $
-                       content
-          commit = Commit tree parents' author' email' timestamp' message'
-
-  objectRawContent commit =
-    B.pack . intercalate "\n" $
-    [tree'] ++  parents' ++ [author', commiter', "", message commit]
-    where tree'      = "tree" ++ " " ++ B.unpack (treeHash commit)
-          parents'   = ["parent" ++ " " ++ B.unpack parent | parent <- parents commit]
-          author'    = "author" ++ " " ++ author commit ++ " " ++ "<" ++ email commit ++ ">" ++ " " ++ timestamp'
-          commiter'  = "commiter" ++ " " ++ author commit ++ " " ++ "<" ++ email commit ++ ">" ++ " " ++ timestamp'
-          timestamp' = formatTime defaultTimeLocale gitTimeFormat (timestamp commit)
-
-  objectPretty = B.unpack . objectRawContent
-
-
 -- Tree
-
-instance Object Tree where
-  objectType _ = TreeType
-
-  objectParse raw = case objType of
-    Just TreeType -> case parseTree raw of
-                       (Just tree) -> return tree
-                       Nothing     -> fail "Not a tree"
-    _             -> fail "Invalid tree"
-    where objType = rawObjectType raw
-
-  objectRawContent (Tree children) = B.concat $
-    [[ B.pack $ show mode, B.pack " "
-     , B.pack name, B.pack "\0"
-     , hash
-     ]
-    | (mode, name, hash) <- children
-    ] >>= return . B.concat
-
-  objectPretty (Tree entries) = intercalate "\n" $
-    [ let objType = case filemode of DirMode -> "tree"
-                                     StdMode -> "blob"
-      in show filemode
-      ++ " "
-      ++ objType
-      ++ " "
-      ++ B.unpack hash
-      ++ "    "
-      ++ name
-    | (filemode, name, hash) <- entries
-    ]
 
 insertToInnerTree :: InnerTreeNode
                   -> (Hash, [FilePath], FilePath)
@@ -351,27 +127,6 @@ treesFromInnerTrees (InnerTree _ nodes) = (Tree content) : descendentTrees
 
         content = blobEntries ++ treeEntries
 treesFromInnerTrees _ = []
-
-parseTree :: B.ByteString -> Maybe Tree
-parseTree raw = do
-  let content = (B.drop 1) . (B.dropWhile (/= '\0')) $ raw
-  let getEntries bs
-        | bs == B.empty = Just []
-        | otherwise     = do
-            let (mode', rest')  = B.break (== ' ') bs
-            let (name', rest'') = B.span (/= '\0') $ B.drop 1 rest'
-            let (hash', rest)   = B.splitAt 20 $ B.drop 1 rest''
-
-            let name = B.unpack name'
-            let hash = B16.encode hash'
-
-            mode <- readMaybe . B.unpack $ mode'
-            restEntries <- getEntries rest
-
-            return $ (mode, name, hash):restEntries
-
-  entries <- getEntries content
-  return . Tree $ entries
 
 treeContentsRecursive :: TreeIO -> IO [(FileMode, FilePath, Hash)]
 treeContentsRecursive = (>>= \(Tree entries) -> treeContentsRecursive' [] entries)

--- a/src/Core/Object.hs
+++ b/src/Core/Object.hs
@@ -5,6 +5,7 @@ import Data.List
 import Data.List.Split
 import Data.Maybe
 import Data.Time
+import Text.Read (readMaybe)
 
 import qualified Codec.Compression.Zlib     as Zlib
 import qualified Crypto.Hash.SHA1           as SHA1
@@ -258,7 +259,7 @@ instance Object Tree where
     where objType = rawObjectType raw
 
   objectRawContent (Tree children) = B.concat $
-    [[ B.pack . stringFromFileMode $ mode, B.pack " "
+    [[ B.pack $ show mode, B.pack " "
      , B.pack name, B.pack "\0"
      , hash
      ]
@@ -268,7 +269,7 @@ instance Object Tree where
   objectPretty (Tree entries) = intercalate "\n" $
     [ let objType = case filemode of DirMode -> "tree"
                                      StdMode -> "blob"
-      in stringFromFileMode filemode
+      in show filemode
       ++ " "
       ++ objType
       ++ " "
@@ -339,7 +340,7 @@ parseTree raw = do
             let name = B.unpack name'
             let hash = B16.encode hash'
 
-            mode <- fileModeFromString . B.unpack $ mode'
+            mode <- readMaybe . B.unpack $ mode'
             restEntries <- getEntries rest
 
             return $ (mode, name, hash):restEntries

--- a/src/Core/Object.hs
+++ b/src/Core/Object.hs
@@ -159,6 +159,10 @@ objectFileContent obj = uncompressed
 rawObjectType :: B.ByteString -> Maybe ObjectType
 rawObjectType = parseObjectType . B.unpack . (B.takeWhile (/= ' '))
 
+-- | Returns the path to the object file given its hash.
+--
+-- >>> hashPath "aabbccddeeff"
+-- ".git/objects/aa/bbccddeeff"
 hashPath :: Hash -> FilePath
 hashPath hash = path
   where hashStr  = B.unpack hash
@@ -166,6 +170,7 @@ hashPath hash = path
         filename = drop 2 $ hashStr
         path     = concat [".git/objects/", dir, "/", filename]
 
+-- | Determines if a loose object file exists given its hash as a string.
 looseObjectExists :: String -> IO Bool
 looseObjectExists hashStr = do
   let path = ".git/objects/" ++ take 2 hashStr ++ "/" ++ drop 2 hashStr

--- a/src/Core/Object.hs
+++ b/src/Core/Object.hs
@@ -20,8 +20,9 @@ import Core.Packfile
 
 data ObjectType = BlobType | TreeType | CommitType
 
-data Tree = Tree [(FileMode, FilePath, Hash)]
-data Blob = Blob B.ByteString
+newtype Tree = Tree [(FileMode, FilePath, Hash)]
+newtype Blob = Blob B.ByteString
+
 data Commit = Commit
   { treeHash  :: Hash
   , parents   :: [Hash]

--- a/src/Core/Object.hs
+++ b/src/Core/Object.hs
@@ -164,17 +164,12 @@ rawObjectType = parseObjectType . B.unpack . (B.takeWhile (/= ' '))
 -- >>> hashPath "aabbccddeeff"
 -- ".git/objects/aa/bbccddeeff"
 hashPath :: Hash -> FilePath
-hashPath hash = path
-  where hashStr  = B.unpack hash
-        dir      = take 2 $ hashStr
-        filename = drop 2 $ hashStr
-        path     = concat [".git/objects/", dir, "/", filename]
+hashPath hash = concat [".git/objects/", dir, "/", filename]
+  where (dir, filename) = splitAt 2 $ B.unpack hash
 
 -- | Determines if a loose object file exists given its hash as a string.
 looseObjectExists :: String -> IO Bool
-looseObjectExists hashStr = do
-  let path = ".git/objects/" ++ take 2 hashStr ++ "/" ++ drop 2 hashStr
-  Dir.doesFileExist path
+looseObjectExists = Dir.doesFileExist . hashPath . B.pack
 
 -- Blob
 

--- a/src/Core/Object/Blob.hs
+++ b/src/Core/Object/Blob.hs
@@ -1,0 +1,34 @@
+--------------------------------------------------------------------------------
+-- |
+-- Module      :  Core.Object.Blob
+-- Copyright   :  (c) Lucas Oshiro 2022
+--
+-- Maintainer  : lucasseikioshiro@gmail.com
+--
+-- This module contains the definition of the 'Blob' object, as well as the
+-- instance of the 'Object' typeclass.
+--------------------------------------------------------------------------------
+
+module Core.Object.Blob (
+    Blob(..)
+  ) where
+
+import Data.ByteString.Char8 (ByteString, unpack, split)
+
+import Core.Object.Core (Object(..), ObjectType(..), rawObjectType)
+
+-- | A Git blob is a file in the Git object database. It is a sequence of bytes.
+newtype Blob = Blob ByteString deriving (Show, Eq)
+
+instance Object Blob where
+  objectParse bs = case objType of
+    Just BlobType -> return . Blob $ content
+    _             -> fail "Not a blob"
+    where objType = rawObjectType bs
+          content = split '\0' bs !! 1
+
+  objectType _ = BlobType
+
+  objectRawContent (Blob content) = content
+
+  objectPretty (Blob bs) = unpack bs

--- a/src/Core/Object/Commit.hs
+++ b/src/Core/Object/Commit.hs
@@ -1,0 +1,88 @@
+--------------------------------------------------------------------------------
+-- |
+-- Module      :  Core.Object.Blob
+-- Copyright   :  (c) Lucas Oshiro 2022
+--
+-- Maintainer  : lucasseikioshiro@gmail.com
+--
+-- This module contains the definition of the 'Commit' object, as well as the
+-- instance of the 'Object' typeclass.
+--------------------------------------------------------------------------------
+
+module Core.Object.Commit (Commit(..)) where
+
+import Data.ByteString.Char8 (pack, unpack)
+import Data.List (intercalate)
+import Data.Maybe (fromJust)
+import Data.Time (ZonedTime, parseTimeM, defaultTimeLocale, formatTime)
+
+import qualified Data.ByteString.Char8 as B
+
+import Core.Core (Hash)
+import Core.Object.Core (Object(..), ObjectType(..), rawObjectType, gitTimeFormat)
+
+-- | A Git commit is a snapshot of the contents of the entire repository at a
+-- given point in time.
+data Commit = Commit
+  { treeHash  :: Hash
+  , parents   :: [Hash]
+  , author    :: String
+  , email     :: String
+  , timestamp :: ZonedTime
+  , message   :: String
+  }
+
+instance Object Commit where
+  objectType _ = CommitType
+
+  objectParse raw =
+    case objType of
+      Just CommitType -> return commit
+      _           -> fail "Not a commit"
+
+    where objType      = rawObjectType raw
+          content      = (B.drop 1) . (B.dropWhile (/= '\0')) $ raw
+          linesB       = B.split '\n' content
+          headerLines  = takeWhile (/= B.empty) linesB
+          treeLine     = headerLines !! 0
+          parentsLines = (takeWhile $ B.isPrefixOf $ pack "parent") .
+                         (drop 1) $
+                         headerLines
+          authorLine   = headerLines !! (length parentsLines + 1)
+
+          tree       = B.drop (length "tree ") treeLine
+          parents'   = [ B.drop (length "parent ") line
+                       | line <- parentsLines
+                       ]
+          author'    = unpack .
+                       B.init .
+                       B.takeWhile (/= '<') .
+                       B.drop (length "author ") $
+                       authorLine
+          email'     = unpack .
+                       B.takeWhile (/= '>') .
+                       B.drop 1 .
+                       B.dropWhile (/= '<') $
+                       authorLine
+          timestampM :: Maybe ZonedTime
+          timestampM = parseTimeM True defaultTimeLocale gitTimeFormat .
+                       unpack .
+                       B.drop 2 .
+                       B.dropWhile (/= '>') $
+                       authorLine
+          timestamp' = fromJust timestampM
+          message'   = unpack $
+                       B.drop (1 + length headerLines + (sum $ map B.length headerLines)) $
+                       content
+          commit = Commit tree parents' author' email' timestamp' message'
+
+  objectRawContent commit =
+    pack . intercalate "\n" $
+    [tree'] ++  parents' ++ [author', commiter', "", message commit]
+    where tree'      = "tree" ++ " " ++ unpack (treeHash commit)
+          parents'   = ["parent" ++ " " ++ unpack parent | parent <- parents commit]
+          author'    = "author" ++ " " ++ author commit ++ " " ++ "<" ++ email commit ++ ">" ++ " " ++ timestamp'
+          commiter'  = "commiter" ++ " " ++ author commit ++ " " ++ "<" ++ email commit ++ ">" ++ " " ++ timestamp'
+          timestamp' = formatTime defaultTimeLocale gitTimeFormat (timestamp commit)
+
+  objectPretty = unpack . objectRawContent

--- a/src/Core/Object/Core.hs
+++ b/src/Core/Object/Core.hs
@@ -1,0 +1,142 @@
+--------------------------------------------------------------------------------
+-- |
+-- Module      :  Core.Object.Core
+-- Copyright   :  (c) Lucas Oshiro 2022
+--
+-- Maintainer  : lucasseikioshiro@gmail.com
+--
+-- This module defines the Object typeclass as well as some functions that load
+-- objects off and store objects to the disk.
+--------------------------------------------------------------------------------
+
+module Core.Object.Core where
+
+import Control.Monad.Extra (unlessM)
+import Data.ByteString.Char8 (ByteString, unpack, pack)
+import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist)
+import System.FilePath (takeDirectory)
+import Text.Read (readMaybe)
+
+import qualified Crypto.Hash.SHA1       as SHA1
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Char8  as B
+
+import Core.Core (Hash)
+import Core.Packfile (PackObjType(..), searchInPackFiles)
+import Util.Util (compress, decompress)
+
+-- | Typeclass for Git objects.
+class Object o where
+  -- | Returns the object type.
+  objectType :: o -> ObjectType
+
+  -- | Parse a 'ByteString' into an object of the given type.
+  objectParse :: ByteString -> IO o
+
+  -- | Serialize the object into a 'ByteString'.
+  objectRawContent :: o -> ByteString
+
+  -- | Pretty print the object.
+  objectPretty :: o -> String
+
+-- | Helper type to enumerate valid Git object types.
+data ObjectType = BlobType | TreeType | CommitType
+
+instance Read ObjectType where
+  readsPrec _ "blob"   = [(BlobType,   "")]
+  readsPrec _ "tree"   = [(TreeType,   "")]
+  readsPrec _ "commit" = [(CommitType, "")]
+  readsPrec _ _        = []
+
+instance Show ObjectType where
+  show BlobType   = "blob"
+  show TreeType   = "tree"
+  show CommitType = "commit"
+
+gitTimeFormat :: String
+gitTimeFormat = "%s %z"
+
+-- | Tries to parse the type of a Git object from its uncompressed contents.
+rawObjectType :: B.ByteString -> Maybe ObjectType
+rawObjectType = readMaybe . B.unpack . B.takeWhile (/= ' ')
+
+-- | Compute the SHA1 hash of an object.
+hashObject :: Object o => o -> Hash
+hashObject = B16.encode . SHA1.hash . objectFileContent
+
+-- | Returns the path to the object file given its hash.
+--
+-- >>> hashPath "aabbccddeeff"
+-- ".git/objects/aa/bbccddeeff"
+hashPath :: Hash -> FilePath
+hashPath hash = concat [".git/objects/", dir, "/", filename]
+  where (dir, filename) = splitAt 2 $ unpack hash
+
+-- | Stores a compressed Git object on disk.
+--
+-- TODO: Support packfiles.
+storeObject :: Object o => o -> IO ()
+storeObject obj = do
+  let objectPath = hashPath $ hashObject obj
+  createDirectoryIfMissing True $ takeDirectory objectPath
+  unlessM (doesDirectoryExist objectPath) $ do
+    B.writeFile objectPath $ compress (objectFileContent obj)
+
+-- | Loads a Git object from disk (either loose or packed) as a 'B.ByteString'.
+loadRawObject :: Hash -> IO B.ByteString
+loadRawObject hash = do
+  exists <- looseObjectExists . B.unpack $ hash
+  if exists
+    then loadLooseRawObject $ hash
+    else do
+      packed <- loadPackedRawObject hash
+
+      case packed of
+        Just b -> return b
+        Nothing -> fail "object not found"
+
+-- | Loads a Git object from disk and attempts to parse it.
+loadObjectLegacy :: Object o => Hash -> IO o
+loadObjectLegacy hash = loadRawObject hash >>= objectParse
+
+-- | Loads a loose Git object from disk as a 'B.ByteString'.
+loadLooseRawObject :: Hash -> IO B.ByteString
+loadLooseRawObject hash = B.readFile (hashPath hash) >>= return . decompress
+
+-- | Loads a packed Git object from disk as a 'Maybe'@ @'B.ByteString'.
+loadPackedRawObject :: Hash -> IO (Maybe B.ByteString)
+loadPackedRawObject hash = do
+  obj <- searchInPackFiles hash
+  return $ do
+    (objType, content) <- obj
+
+    typeStr <- case objType of
+                    PackBlob   -> Just . B.pack $ "blob"
+                    PackTree   -> Just . B.pack $ "tree"
+                    PackCommit -> Just . B.pack $ "commit"
+                    _          -> Nothing
+
+    let decompressed = decompress content
+        size = B.length decompressed
+
+    return . B.concat $ [ typeStr
+                        , B.pack " "
+                        , B.pack . show $ size
+                        , B.pack "\0"
+                        , decompressed
+                        ]
+
+-- | Determines if a loose object file exists given its hash as a string.
+looseObjectExists :: String -> IO Bool
+looseObjectExists = doesFileExist . hashPath . pack
+
+-- | Get the uncompressed contents of an object as a 'ByteString'.
+objectFileContent :: Object o => o -> ByteString
+objectFileContent obj = uncompressed
+  where content      = objectRawContent obj
+        size         = pack $ show $ B.length content
+        objType      = objectType obj
+        uncompressed = B.concat [ pack $ show objType
+                                , pack " "
+                                , size
+                                , pack "\0", content]

--- a/src/Core/Object/Tree.hs
+++ b/src/Core/Object/Tree.hs
@@ -1,0 +1,76 @@
+--------------------------------------------------------------------------------
+-- |
+-- Module      :  Core.Object.Blob
+-- Copyright   :  (c) Lucas Oshiro 2022
+--
+-- Maintainer  : lucasseikioshiro@gmail.com
+--
+-- This modules contains the definition of the 'Tree' object as well as the
+-- instance of the 'Object' typeclass.
+--------------------------------------------------------------------------------
+
+module Core.Object.Tree (Tree(..)) where
+
+import Data.ByteString.Char8 (pack, unpack)
+import Data.List (intercalate)
+import Text.Read (readMaybe)
+
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Char8  as B
+
+import Core.Core (Hash, FileMode(..))
+import Core.Object.Core (Object(..), ObjectType(..), rawObjectType)
+
+newtype Tree = Tree [(FileMode, FilePath, Hash)]
+
+instance Object Tree where
+  objectType _ = TreeType
+
+  objectParse raw = case objType of
+    Just TreeType -> case parseTree raw of
+                       (Just tree) -> return tree
+                       Nothing     -> fail "Not a tree"
+    _             -> fail "Invalid tree"
+    where objType = rawObjectType raw
+
+  objectRawContent (Tree children) = B.concat $
+    [[ pack $ show mode, pack " "
+     , pack name, pack "\0"
+     , hash
+     ]
+    | (mode, name, hash) <- children
+    ] >>= return . B.concat
+
+  objectPretty (Tree entries) = intercalate "\n" $
+    [ let objType = case filemode of DirMode -> "tree"
+                                     StdMode -> "blob"
+      in show filemode
+      ++ " "
+      ++ objType
+      ++ " "
+      ++ unpack hash
+      ++ "    "
+      ++ name
+    | (filemode, name, hash) <- entries
+    ]
+
+parseTree :: B.ByteString -> Maybe Tree
+parseTree raw = do
+  let content = (B.drop 1) . (B.dropWhile (/= '\0')) $ raw
+  let getEntries bs
+        | bs == B.empty = Just []
+        | otherwise     = do
+            let (mode', rest')  = B.break (== ' ') bs
+            let (name', rest'') = B.span (/= '\0') $ B.drop 1 rest'
+            let (hash', rest)   = B.splitAt 20 $ B.drop 1 rest''
+
+            let name = B.unpack name'
+            let hash = B16.encode hash'
+
+            mode <- readMaybe . B.unpack $ mode'
+            restEntries <- getEntries rest
+
+            return $ (mode, name, hash):restEntries
+
+  entries <- getEntries content
+  return . Tree $ entries

--- a/src/Util/Util.hs
+++ b/src/Util/Util.hs
@@ -20,10 +20,23 @@ trim :: String -> String
 trim = f . f
    where f = reverse . dropWhile isSpace
 
+-- | Divide a 'B.ByteString' into a list of 'B.ByteString' slices according to
+-- a list of spans / lengths. Each 'B.ByteString' in the resulting list will
+-- have length equal to the span that generated it. If the original string is
+-- longer than the sum of all spans, the remaining slice will be added to the
+-- end of the resulting slice list.
+--
+-- >>> sliceByteString [1, 2, 3] "abcdef"
+-- ["a","bc","def"]
+--
+-- >>> sliceByteString [1, 2] "abcdef"
+-- ["a","bc","def"]
+--
+-- >>> sliceByteString [1, 2, 3, 4] "abc"
+-- ["a","bc","",""]
 sliceByteString :: [Int] -> B.ByteString -> [B.ByteString]
-sliceByteString [] bs = if bs /= B.empty then [bs] else []
-sliceByteString (size:rest) bs = (B.take size bs) :
-                                 (sliceByteString rest $ B.drop size bs)
+sliceByteString [] bs = [ bs | bs /= B.empty ]
+sliceByteString (s:ss) bs = B.take s bs : sliceByteString ss (B.drop s bs)
 
 toByteString :: Bin.Binary b => b -> B.ByteString
 toByteString = L.toStrict . Bin.encode

--- a/src/Util/Util.hs
+++ b/src/Util/Util.hs
@@ -11,11 +11,18 @@ import Data.Int
 import Data.List
 import System.Directory
 
+-- | Inverts a 'Map.Map' by mapping its values to their /preimage/ in the
+-- original 'Map.Map'. The order of the original keys in the preimage is not
+-- guaranteed, unless by 'foldl'.
+--
+-- >>> invertMap $ fromList [(1, 3), (2, 3), (10, 1)]
+-- fromList [(1,[10]),(3,[2,1])]
 invertMap :: Ord b => Map.Map a b -> Map.Map b [a]
 invertMap m = foldl addInverted initial (Map.toList m)
   where initial = Map.fromList [ (v, []) | (_, v) <- Map.toList m]
         addInverted inverted (k, v) = Map.insertWith (++) v [k] inverted
 
+-- | Trim whitespace from the ends of a 'String'.
 trim :: String -> String
 trim = f . f
    where f = reverse . dropWhile isSpace
@@ -38,21 +45,30 @@ sliceByteString :: [Int] -> B.ByteString -> [B.ByteString]
 sliceByteString [] bs = [ bs | bs /= B.empty ]
 sliceByteString (s:ss) bs = B.take s bs : sliceByteString ss (B.drop s bs)
 
+-- | Serialize 'Bin.Binary' types into a strict 'B.ByteString'.
 toByteString :: Bin.Binary b => b -> B.ByteString
 toByteString = L.toStrict . Bin.encode
 
+-- | Convert an 'Integral' type into a 32-bit integer. Beware of overflows.
 to32 :: Integral a => a -> Int32
 to32 = fromIntegral
 
+-- | Convert an 'Integral' type into a 64-bit integer. Beware of overflows.
 to64 :: Integral a => a -> Int64
 to64 = fromIntegral
 
+-- | Serialize an 'Integral' type into a 'B.ByteString' by first converting it
+-- into a 32-bit integer. Beware of overflows.
 toBS32 :: Integral a => a -> B.ByteString
 toBS32 = toByteString . to32
 
+-- | Serialize an 'Integral' type into a 'B.ByteString' by first converting it
+-- into a 64-bit integer. Beware of overflows.
 toBS64 :: Integral a => a -> B.ByteString
 toBS64 = toByteString . to64
 
+-- | Produce a list with the paths to all directories and files under a given
+-- 'FilePath', recursively.
 listDirectoryRecursive :: FilePath -> IO [FilePath]
 listDirectoryRecursive path = do
   contents <- map ((path ++ "/") ++) . delete ".git" <$> listDirectory path
@@ -60,8 +76,15 @@ listDirectoryRecursive path = do
   recursiveList <- join <$> mapM listDirectoryRecursive directories
   return $ contents ++ recursiveList
 
+-- | Produce a 'Map.Map' out of the common keys of two given maps, where the
+-- value at key @k@ is @(a,b)@, where @a@ is the value at @k@ in the first map,
+-- and @b@ is the value at @k@ in the second map.
+--
+-- >>> zipMap (fromList [(1, "a"), (2, "b")]) (fromList [(2, "x"), (3, "y")])
+-- fromList [(2,("b","x"))]
 zipMap :: Ord k => Map.Map k a -> Map.Map k b -> Map.Map k (a, b)
 zipMap = Map.intersectionWith (,)
 
+-- | Read a octal number written as a 'String' into an 'Int'.
 parseOctal :: String -> Int
 parseOctal = read . ("0o" ++)

--- a/src/Util/Util.hs
+++ b/src/Util/Util.hs
@@ -56,7 +56,7 @@ listDirectoryRecursive path = do
   x >>= return . (>>= id)
 
 zipMap :: Ord k => Map.Map k a -> Map.Map k b -> Map.Map k (a, b)
-zipMap m1 m2 = Map.mapWithKey (\k v1 -> (v1, m2 Map.! k)) m1
+zipMap = Map.intersectionWith (,)
 
 parseOctal :: String -> Int
 parseOctal = read . ("0o" ++)

--- a/src/Util/Util.hs
+++ b/src/Util/Util.hs
@@ -10,6 +10,7 @@
 
 module Util.Util where
 
+import qualified Codec.Compression.Zlib     as Zlib
 import qualified Data.Binary                as Bin
 import qualified Data.ByteString.Char8      as B
 import qualified Data.ByteString.Lazy.Char8 as L
@@ -98,3 +99,11 @@ zipMap = Map.intersectionWith (,)
 -- | Read a octal number written as a 'String' into an 'Int'.
 parseOctal :: String -> Int
 parseOctal = read . ("0o" ++)
+
+-- | Compresses a 'B.ByteString' using zlib.
+compress :: B.ByteString -> B.ByteString
+compress = L.toStrict . Zlib.compress . L.fromStrict
+
+-- | Decompresses a 'B.ByteString' using zlib.
+decompress :: B.ByteString -> B.ByteString
+decompress = L.toStrict . Zlib.decompress . L.fromStrict

--- a/src/Util/Util.hs
+++ b/src/Util/Util.hs
@@ -1,3 +1,13 @@
+--------------------------------------------------------------------------------
+-- |
+-- Module      :  Util.Util
+-- Copyright   :  (c) Lucas Oshiro 2022
+--
+-- Maintainer  : lucasseikioshiro@gmail.com
+--
+-- This module contains utility functions to be used elsewhere in this project.
+--------------------------------------------------------------------------------
+
 module Util.Util where
 
 import qualified Data.Binary                as Bin

--- a/test/Core/CoreSpec.hs
+++ b/test/Core/CoreSpec.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE StandaloneDeriving #-}
+module Core.CoreSpec (spec) where
+
+import Test.Hspec
+
+import Core.Core
+
+deriving instance Eq   FileMode
+deriving instance Show FileMode
+
+spec :: Spec
+spec = do
+  describe "FileMode" $ do
+    it "is properly converted to string" $ do
+      stringFromFileMode StdMode `shouldBe` "100644"
+      stringFromFileMode DirMode `shouldBe` "40000"
+
+    it "is properly converted from string" $ do
+      fileModeFromString "100644" `shouldBe` Just StdMode
+      fileModeFromString "40000"  `shouldBe` Just DirMode

--- a/test/Core/CoreSpec.hs
+++ b/test/Core/CoreSpec.hs
@@ -4,6 +4,8 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.Oshit ()
 
+import Control.Exception (evaluate)
+
 import Core.Core
 
 spec :: Spec
@@ -11,3 +13,7 @@ spec = do
   describe "FileMode" $ do
     prop "has an isomorphism in read/show" $ \fm -> do
       read (show fm) `shouldBe` (fm :: FileMode)
+
+    context "when read from an invalid string" $ do
+      it "throws an ErrorCall exception" $ do
+        evaluate (read "123456" :: FileMode) `shouldThrow` anyErrorCall

--- a/test/Core/CoreSpec.hs
+++ b/test/Core/CoreSpec.hs
@@ -1,20 +1,13 @@
-{-# LANGUAGE StandaloneDeriving #-}
 module Core.CoreSpec (spec) where
 
 import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.Oshit ()
 
 import Core.Core
-
-deriving instance Eq   FileMode
-deriving instance Show FileMode
 
 spec :: Spec
 spec = do
   describe "FileMode" $ do
-    it "is properly converted to string" $ do
-      stringFromFileMode StdMode `shouldBe` "100644"
-      stringFromFileMode DirMode `shouldBe` "40000"
-
-    it "is properly converted from string" $ do
-      fileModeFromString "100644" `shouldBe` Just StdMode
-      fileModeFromString "40000"  `shouldBe` Just DirMode
+    prop "has an isomorphism in read/show" $ \fm -> do
+      read (show fm) `shouldBe` (fm :: FileMode)

--- a/test/Core/ObjectSpec.hs
+++ b/test/Core/ObjectSpec.hs
@@ -30,6 +30,12 @@ spec = do
     prop "returns False if the object does not exist" $ forAll sha1Gen $ \hash -> do
       looseObjectExists hash `shouldReturn` False
 
+  describe "storeObject :: Object o => o -> IO ()" $ around_ withTempDir $ do
+    prop "stores blobs in the .git directory" $ \blob -> do
+      let blobPath = hashPath $ hashObject (blob :: Blob)
+      storeObject blob
+      doesFileExist blobPath `shouldReturn` True
+
 withTempDir :: IO () -> IO ()
 withTempDir action = do
   current <- getCurrentDirectory

--- a/test/Core/ObjectSpec.hs
+++ b/test/Core/ObjectSpec.hs
@@ -1,0 +1,40 @@
+module Core.ObjectSpec (spec) where
+
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
+import Test.Oshit (sha1Gen)
+
+import Data.ByteString.Char8 (pack)
+import Text.Printf (printf)
+import System.Directory
+import System.FilePath (takeDirectory)
+import System.IO.Temp (createTempDirectory)
+
+import Core.Object
+
+spec :: Spec
+spec = do
+  describe "hashPath :: Hash -> FilePath" $ do
+    prop "returns the path to the object in .git" $ forAll sha1Gen $ \hash -> do
+      let expectedPath = printf ".git/objects/%s/%s" (take 2 hash) (drop 2 hash)
+      hashPath (pack hash) `shouldBe` expectedPath
+
+  describe "looseObjectExists :: String -> IO Bool" $ around_ withTempDir $ do
+    prop "returns True if the object exists" $ forAll sha1Gen $ \hash -> do
+      let objectPath = hashPath (pack hash)
+      createDirectoryIfMissing True (takeDirectory objectPath)
+      writeFile objectPath ""
+      looseObjectExists hash `shouldReturn` True
+
+    prop "returns False if the object does not exist" $ forAll sha1Gen $ \hash -> do
+      looseObjectExists hash `shouldReturn` False
+
+withTempDir :: IO () -> IO ()
+withTempDir action = do
+  current <- getCurrentDirectory
+  tempDir <- createTempDirectory current "hspec-util-utilspec"
+  setCurrentDirectory tempDir -- work inside tmp directory
+  action
+  setCurrentDirectory current
+  removeDirectoryRecursive tempDir

--- a/test/Test/Oshit.hs
+++ b/test/Test/Oshit.hs
@@ -23,6 +23,7 @@ import Data.Fixed (Pico)
 import Data.Time.Lens (modL, seconds)
 import Text.Printf (printf)
 
+import Core.Core (FileMode(..))
 import Core.Reflog (ReflogEntry(..))
 
 -- | Orphan instance of MonadFail for Test.QuickCheck.Gen, for pattern matching.
@@ -68,3 +69,7 @@ instance Arbitrary ReflogEntry where
                        , author = au, email = em
                        , timestamp = st, title = tt
                        }
+
+-- | Generate a random FileMode.
+instance Arbitrary FileMode where
+  arbitrary = elements [ StdMode, DirMode ]

--- a/test/Test/Oshit.hs
+++ b/test/Test/Oshit.hs
@@ -17,7 +17,7 @@ import Test.QuickCheck.Instances.Time ()
 
 import qualified ASCII.Char as ASCII
 import ASCII.Lists
-import Data.ByteString.Char8 (pack)
+import Data.ByteString.Char8 (ByteString, pack)
 import Data.Char (chr)
 import Data.Fixed (Pico)
 import Data.Time.Lens (modL, seconds)
@@ -73,3 +73,7 @@ instance Arbitrary ReflogEntry where
 -- | Generate a random FileMode.
 instance Arbitrary FileMode where
   arbitrary = elements [ StdMode, DirMode ]
+
+-- | Generate a random ByteString from a random String.
+instance Arbitrary ByteString where
+  arbitrary = pack <$> arbitrary

--- a/test/Test/Oshit.hs
+++ b/test/Test/Oshit.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE StandaloneDeriving #-}
-
 module Test.Oshit where
 
 -- -----------------------------------------------------------------------------
@@ -28,8 +26,6 @@ import Text.Printf (printf)
 import Core.Core (FileMode(..))
 import Core.Reflog (ReflogEntry(..))
 import Core.Object (Blob(..))
-
-deriving instance Show Blob
 
 -- | Orphan instance of MonadFail for Test.QuickCheck.Gen, for pattern matching.
 instance MonadFail Gen where

--- a/test/Test/Oshit.hs
+++ b/test/Test/Oshit.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE StandaloneDeriving #-}
+
 module Test.Oshit where
 
 -- -----------------------------------------------------------------------------
@@ -25,6 +27,9 @@ import Text.Printf (printf)
 
 import Core.Core (FileMode(..))
 import Core.Reflog (ReflogEntry(..))
+import Core.Object (Blob(..))
+
+deriving instance Show Blob
 
 -- | Orphan instance of MonadFail for Test.QuickCheck.Gen, for pattern matching.
 instance MonadFail Gen where
@@ -77,3 +82,7 @@ instance Arbitrary FileMode where
 -- | Generate a random ByteString from a random String.
 instance Arbitrary ByteString where
   arbitrary = pack <$> arbitrary
+
+-- | Generate a random Blob.
+instance Arbitrary Blob where
+  arbitrary = Blob <$> arbitrary

--- a/test/Util/UtilSpec.hs
+++ b/test/Util/UtilSpec.hs
@@ -11,7 +11,7 @@ import Data.Map hiding (take, drop, map)
 import Data.Text.Lazy (unpack)
 import Formatting (format)
 import Formatting.Formatters (oct)
-import Safe (headMay, lastMay)
+import Safe (headMay, lastMay, initSafe)
 import System.Directory
 import System.IO.Temp (createTempDirectory)
 
@@ -47,6 +47,15 @@ spec = do
           slices = sliceByteString spans toBeSliced
           spans = map abs spans'
       map BS.length slices `shouldBe` spans
+      BS.concat slices `shouldBe` toBeSliced
+
+    prop "adds empty slices for insufficiently long bytestring" $ \spans' -> do
+      let toBeSliced = BS.pack $ replicate (sum $ initSafe spans) ' '
+          mismatches = dropWhile (\(s,sl) -> BS.length sl == s) $ zip spans slices
+          slices = sliceByteString spans toBeSliced
+          spans = map abs spans'
+      length slices `shouldSatisfy` flip elem [length spans', length spans' + 1]
+      mismatches `shouldSatisfy` all (\(_,sl) -> sl == BS.empty)
       BS.concat slices `shouldBe` toBeSliced
 
     prop "returns a singleton or nothing when given no spans" $ \bs -> do

--- a/test/Util/UtilSpec.hs
+++ b/test/Util/UtilSpec.hs
@@ -1,0 +1,62 @@
+module Util.UtilSpec (spec) where
+
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.Oshit ()
+
+import Control.DeepSeq (force)
+import Control.Exception (evaluate)
+import Data.Char (isSpace)
+import Data.List.Index (indexed)
+import Data.Map hiding (take, drop, map)
+import Data.Text.Lazy (unpack)
+import Formatting (format)
+import Formatting.Formatters (oct)
+import Safe (headMay, lastMay)
+
+import qualified Data.ByteString.Char8 as BS
+
+import Util.Util
+
+spec :: Spec
+spec = do
+  describe "parseOctal :: String -> Int" $ do
+    prop "reliably parses an octal string" $ \i -> do
+      parseOctal (unpack $ format oct (abs i)) `shouldBe` abs i
+
+  describe "zipMap :: Ord k => Map k a -> Map k b -> Map k (a,b)" $ do
+    prop "zips maps with keys in common" $ \s -> do
+      let mapA :: Map Int String
+          mapA = fromList $ indexed s
+          mapC = zipMap mapA mapA
+      shouldSatisfy (keys mapC) . all $ uncurry (==) . (mapC !)
+
+    it "throws an ErrorCall when the 1st map has extra keys" $ do
+      let mapA, mapB :: Map Int Int
+          mapA = fromList [(1,  2), (2,  3), (3, 4)]
+          mapB = fromList [(1, 10), (2, 20)]
+      evaluate (force $ zipMap mapA mapB) `shouldThrow` anyErrorCall
+
+  describe "trim :: String -> String" $ do
+    prop "strips whitespace on the ends of a string" $ \s -> do
+      headMay (trim s) `shouldSatisfy` maybe True (not . isSpace)
+      lastMay (trim s) `shouldSatisfy` maybe True (not . isSpace)
+
+    prop "doesn't alter strings with no edge whitespace" $ \s -> do
+      trim ("(" ++ s ++ ")") `shouldBe` ("(" ++ s ++ ")")
+
+  describe "sliceByteString :: [Int] -> ByteString -> [ByteString]" $ do
+    prop "properly slices a sufficiently long bytestring" $ \spans' -> do
+      let toBeSliced = BS.pack $ replicate (sum spans) ' '
+          slices = sliceByteString spans toBeSliced
+          spans = map abs spans'
+      map BS.length slices `shouldBe` spans
+      BS.concat slices `shouldBe` toBeSliced
+
+    prop "returns a singleton or nothing when given no spans" $ \bs -> do
+      sliceByteString [] bs `shouldBe` [bs | bs /= BS.empty]
+
+  describe "invertMap :: Ord b => Map a b -> Map b [a]" $ do
+    prop "properly inverts a random map" $ \m -> do
+      let inverted = invertMap (m :: Map Int Int)
+      shouldSatisfy inverted $ \inv -> all (\(a,b) -> a `elem` inv ! b) (toList m)

--- a/test/Util/UtilSpec.hs
+++ b/test/Util/UtilSpec.hs
@@ -66,18 +66,22 @@ spec = do
       let inverted = invertMap (m :: Map Int Int)
       shouldSatisfy inverted $ \inv -> all (\(a,b) -> a `elem` inv ! b) (toList m)
 
-  describe "listDirectoryRecursive :: FilePath -> IO [FilePath]" $ do
+  describe "listDirectoryRecursive :: FilePath -> IO [FilePath]" $ around_ withTempDirStructure $ do
     it "recursively lists directories" $ do
-      current <- getCurrentDirectory
-      tempDir <- createTempDirectory current "hspec-util-utilspec"
-
-      setCurrentDirectory tempDir -- work inside tmp directory
-      createDirectory "a" >> createDirectory "a/b"
-      writeFile "a/b/c" "" >> writeFile "a/d" ""
-      writeFile "e" ""
-
       files <- listDirectoryRecursive "."
       sort files `shouldBe` sort ["./a", "./a/b", "./a/b/c", "./a/d", "./e"]
 
-      setCurrentDirectory current
-      removeDirectoryRecursive tempDir
+withTempDirStructure :: IO () -> IO ()
+withTempDirStructure action = do
+  current <- getCurrentDirectory
+  tempDir <- createTempDirectory current "hspec-util-utilspec"
+
+  setCurrentDirectory tempDir -- work inside tmp directory
+  createDirectory "a" >> createDirectory "a/b"
+  writeFile "a/b/c" "" >> writeFile "a/d" ""
+  writeFile "e" ""
+
+  action
+
+  setCurrentDirectory current
+  removeDirectoryRecursive tempDir

--- a/test/Util/UtilSpec.hs
+++ b/test/Util/UtilSpec.hs
@@ -71,6 +71,11 @@ spec = do
       files <- listDirectoryRecursive "."
       sort files `shouldBe` sort ["./a", "./a/b", "./a/b/c", "./a/d", "./e"]
 
+    it "ignores .git directories" $ do
+      createDirectory ".git" >> createDirectory "a/.git"
+      files <- listDirectoryRecursive "."
+      sort files `shouldBe` sort ["./a", "./a/b", "./a/b/c", "./a/d", "./e"]
+
 withTempDirStructure :: IO () -> IO ()
 withTempDirStructure action = do
   current <- getCurrentDirectory

--- a/test/Util/UtilSpec.hs
+++ b/test/Util/UtilSpec.hs
@@ -4,8 +4,6 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.Oshit ()
 
-import Control.DeepSeq (force)
-import Control.Exception (evaluate)
 import Data.Char (isSpace)
 import Data.List.Index (indexed)
 import Data.Map hiding (take, drop, map)
@@ -25,17 +23,12 @@ spec = do
       parseOctal (unpack $ format oct (abs i)) `shouldBe` abs i
 
   describe "zipMap :: Ord k => Map k a -> Map k b -> Map k (a,b)" $ do
-    prop "zips maps with keys in common" $ \s -> do
+    prop "zips maps disregarding exclusive keys" $ \s -> do
       let mapA :: Map Int String
           mapA = fromList $ indexed s
-          mapC = zipMap mapA mapA
-      shouldSatisfy (keys mapC) . all $ uncurry (==) . (mapC !)
-
-    it "throws an ErrorCall when the 1st map has extra keys" $ do
-      let mapA, mapB :: Map Int Int
-          mapA = fromList [(1,  2), (2,  3), (3, 4)]
-          mapB = fromList [(1, 10), (2, 20)]
-      evaluate (force $ zipMap mapA mapB) `shouldThrow` anyErrorCall
+          mapB = fromList . indexed $ drop 1 s
+          mapC = zipMap mapA mapB
+      shouldSatisfy (keys mapC) . all $ \k -> mapC ! k == (mapA ! k, mapB ! k)
 
   describe "trim :: String -> String" $ do
     prop "strips whitespace on the ends of a string" $ \s -> do


### PR DESCRIPTION
Built on top of #3, this PR adds further minor improvements and tests that use QuickCheck for property testing.

Summary of changes since #3:

- `Core.Core`:
  - 87d59ed adab2a0 Tests were included for the conversion to/from `String` for `FileMode`.
  - 802ef1a Instances of `Read` and `Show` for `FileMode` replaced the parse/unparse functions.
- `Core.Object`:
  - fc3059a The `newtype` keyword is now used for `Tree` and `Blob` for added strictness.
  - 42a8afc The `looseObjectExists` and `hashPath` functions were refactored for the sake of brevity.
  - 7886f94 A property test was added for `storeObject`, using a new instance of `Arbitrary` for `Blob`.
  - 3950c65 With the help of the `filepath` and `extra` packages, `storeObject` was rewritten.
  - 92be468 Instance of `Read` and `Show` for `ObjectType` replaced the parse/unparse functions.
  - 55cc3cd Code for the `Commit`, `Tree`, and `Blob` objects was split into separate files. Kind of WIP.
  - Haddock additions: 4aa9e71 ad63c56
- `Util.Util`:
  - 5a35064 `zipMap` now uses `intersectionWith`, from `Data.Map`.
  - 366dfea `listDirectoryRecursive` was rewritten using fewer lines, with a change in the order of the output list.
  - 55cc3cd `compress` and `decompress` were moved to the module.
  - Unit testing: 2ed6fe6 e081483 bf83c86 385ca6f 811166c
  - Haddock additions: 21a13cd e84c817 a451c3a

Until #3 is merged, this pull request will remain as a draft.