### PR TITLE
object: remove ObjectIO

### DIFF
--- a/src/Commands/Plumbing/Merge/MergeCommit.hs
+++ b/src/Commands/Plumbing/Merge/MergeCommit.hs
@@ -10,7 +10,7 @@ import qualified Data.ByteString.Char8      as B
 
 treeFromCommit :: Hash -> IO Tree
 treeFromCommit hash = do
-  commit <- loadObject hash :: IO Commit
+  commit <- loadObject hash
   loadObject $ treeHash commit
 
 cmdMergeCommit :: Command

--- a/src/Commands/Plumbing/Merge/MergeCommit.hs
+++ b/src/Commands/Plumbing/Merge/MergeCommit.hs
@@ -9,9 +9,7 @@ import Data.Time
 import qualified Data.ByteString.Char8      as B
 
 treeFromCommit :: Hash -> IO Tree
-treeFromCommit hash = do
-  commit <- loadObject hash
-  loadObject $ treeHash commit
+treeFromCommit h = loadObject h >>= loadObject . treeHash
 
 cmdMergeCommit :: Command
 cmdMergeCommit (o:a:b:au:em:_) = do

--- a/src/Commands/Plumbing/Merge/MergeCommit.hs
+++ b/src/Commands/Plumbing/Merge/MergeCommit.hs
@@ -8,10 +8,10 @@ import Data.Time
 
 import qualified Data.ByteString.Char8      as B
 
-treeFromCommit :: Hash -> TreeIO
+treeFromCommit :: Hash -> IO Tree
 treeFromCommit hash = do
-  commit <- loadCommit hash
-  loadTree $ treeHash commit
+  commit <- loadObject hash :: IO Commit
+  loadObject $ treeHash commit
 
 cmdMergeCommit :: Command
 cmdMergeCommit (o:a:b:au:em:_) = do

--- a/src/Commands/Plumbing/Merge/MergeTree.hs
+++ b/src/Commands/Plumbing/Merge/MergeTree.hs
@@ -8,10 +8,8 @@ import qualified Data.ByteString.Char8      as B
 
 cmdMergeTree :: Command
 cmdMergeTree (o:a:b:_) = do
-  let (hashO, hashA, hashB) = (B.pack o, B.pack a, B.pack b)
-  let treeO = loadObject hashO
-  let treeA = loadObject hashA
-  let treeB = loadObject hashB
+  let (treeO, treeA, treeB) = (hashToTree o, hashToTree a, hashToTree b)
+      hashToTree = loadObject . B.pack
 
   merged <- mergeTree treeO treeA treeB
   putStrLn $ B.unpack . hashObject $ merged

--- a/src/Commands/Plumbing/Merge/MergeTree.hs
+++ b/src/Commands/Plumbing/Merge/MergeTree.hs
@@ -9,9 +9,9 @@ import qualified Data.ByteString.Char8      as B
 cmdMergeTree :: Command
 cmdMergeTree (o:a:b:_) = do
   let (hashO, hashA, hashB) = (B.pack o, B.pack a, B.pack b)
-  let treeO = loadTree hashO
-  let treeA = loadTree hashA
-  let treeB = loadTree hashB
+  let treeO = loadObject hashO
+  let treeA = loadObject hashA
+  let treeB = loadObject hashB
 
   merged <- mergeTree treeO treeA treeB
   putStrLn $ B.unpack . hashObject $ merged

--- a/src/Commands/Plumbing/Object/ListTree.hs
+++ b/src/Commands/Plumbing/Object/ListTree.hs
@@ -8,7 +8,7 @@ import qualified Data.ByteString.Char8 as B
 cmdListTree :: Command
 cmdListTree [hash'] = do
   let hash = B.pack hash'
-  let tree = loadTree hash
+  let tree = loadObject hash
   contents <- listTreeRecursive tree
   sequence_ . map putStrLn $ contents
 cmdListTree _ = fail "tree not provided"

--- a/src/Commands/Porcelain/Merge/CherryPick.hs
+++ b/src/Commands/Porcelain/Merge/CherryPick.hs
@@ -18,23 +18,23 @@ cmdCherryPick (hash:_) = do
         (Right _)      -> fail "Cannot cherry-pick in detached HEAD"
 
   headCommitHash <- getHeadCommitHash
-  headCommit <- loadCommit headCommitHash
+  headCommit <- loadObject headCommitHash
   let Commit {treeHash = headTreeHash} = headCommit
-  let headTree = loadTree headTreeHash
+  let headTree = loadObject headTreeHash
 
-  cherryPickCommit <- loadCommit . B.pack $ hash
+  cherryPickCommit <- loadObject . B.pack $ hash
   let Commit { parents = cherryPickParents
              , treeHash = cherryPickTreeHash
              } = cherryPickCommit
-  let cherryPickTree = loadTree cherryPickTreeHash
+  let cherryPickTree = loadObject cherryPickTreeHash
 
   parentCommitHash <-
     if cherryPickParents /= []
     then return . head $ cherryPickParents
     else fail "Cannot cherry-pick initial commit!"
-  parentCommit <- loadCommit parentCommitHash
+  parentCommit <- loadObject parentCommitHash
   let Commit {treeHash = parentTreeHash} = parentCommit
-  let parentTree = loadTree parentTreeHash
+  let parentTree = loadObject parentTreeHash
 
   mergedTree <- mergeTree parentTree cherryPickTree headTree
   let mergedHash = hashObject mergedTree

--- a/src/Core/Index.hs
+++ b/src/Core/Index.hs
@@ -289,7 +289,7 @@ indexFromTree' path ((entryMode, name, entryHash):rest) =
     let rawFullPath = intercalate "/" fullPath
 
     let subIndex = case entryMode of
-          DirMode -> loadObjectLegacy entryHash >>= \(Tree entries) -> indexFromTree' fullPath entries
+          DirMode -> loadObject entryHash >>= \(Tree entries) -> indexFromTree' fullPath entries
           StdMode -> return $ addBlobToIndex rawFullPath entryHash Map.empty
 
     it <- subIndex

--- a/src/Core/Merge.hs
+++ b/src/Core/Merge.hs
@@ -19,7 +19,7 @@ threeWayMerge o a b
   | b == o = Just a
   | otherwise = Nothing
 
-mergeTree :: TreeIO -> TreeIO -> TreeIO -> TreeIO
+mergeTree :: IO Tree -> IO Tree -> IO Tree -> IO Tree
 mergeTree o a b = do
   -- Just handling content merge. File permission and submodule merge not
   -- implemented yet. We're not detecting renames. By now we're just giving


### PR DESCRIPTION
Removing ObjectIO and replacing it by Object o => IO o, as discussed in https://github.com/lucasoshiro/oshit/discussions/7.